### PR TITLE
Implement AreaPlayerControl plugin skeleton

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.example'
+version = '1.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+    maven { url 'https://papermc.io/repo/repository/maven-public/' }
+}
+
+dependencies {
+    compileOnly 'io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT'
+    compileOnly 'com.sk89q.worldedit:worldedit-bukkit:7.2.17'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'AreaPlayerControl'

--- a/src/main/java/com/example/areaplayercontrol/AreaPlayerControl.java
+++ b/src/main/java/com/example/areaplayercontrol/AreaPlayerControl.java
@@ -1,0 +1,165 @@
+package com.example.areaplayercontrol;
+
+import com.sk89q.worldedit.bukkit.WorldEditPlugin;
+import com.sk89q.worldedit.bukkit.selections.Selection;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class AreaPlayerControl extends JavaPlugin {
+    private Map<String, Region> regions = new HashMap<>();
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        loadRegions();
+    }
+
+    @Override
+    public void onDisable() {
+        saveRegions();
+    }
+
+    private void loadRegions() {
+        FileConfiguration config = getConfig();
+        if (config.isConfigurationSection("regions")) {
+            for (String key : config.getConfigurationSection("regions").getKeys(false)) {
+                String path = "regions." + key + ".";
+                Location pos1 = config.getLocation(path + "pos1");
+                Location pos2 = config.getLocation(path + "pos2");
+                if (pos1 != null && pos2 != null) {
+                    regions.put(key, new Region(pos1, pos2));
+                }
+            }
+        }
+    }
+
+    private void saveRegions() {
+        FileConfiguration config = getConfig();
+        config.set("regions", null); // clear
+        for (Map.Entry<String, Region> entry : regions.entrySet()) {
+            String path = "regions." + entry.getKey() + ".";
+            config.set(path + "pos1", entry.getValue().pos1);
+            config.set(path + "pos2", entry.getValue().pos2);
+        }
+        saveConfig();
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage("/area <save|remove|info|list> [name]");
+            return true;
+        }
+        String sub = args[0].toLowerCase();
+        if (sub.equals("save")) {
+            if (!(sender instanceof Player)) {
+                sender.sendMessage("Only players can use this command");
+                return true;
+            }
+            if (args.length < 2) {
+                sender.sendMessage("Usage: /area save <name>");
+                return true;
+            }
+            Player player = (Player) sender;
+            Region region = getSelection(player);
+            if (region == null) {
+                sender.sendMessage("You must make a WorldEdit selection first");
+                return true;
+            }
+            regions.put(args[1], region);
+            sender.sendMessage("Region " + args[1] + " saved.");
+            return true;
+        } else if (sub.equals("remove")) {
+            if (args.length < 2) {
+                sender.sendMessage("Usage: /area remove <name>");
+                return true;
+            }
+            if (regions.remove(args[1]) != null) {
+                sender.sendMessage("Region " + args[1] + " removed.");
+            } else {
+                sender.sendMessage("Region not found");
+            }
+            return true;
+        } else if (sub.equals("info")) {
+            if (args.length < 2) {
+                sender.sendMessage("Usage: /area info <name>");
+                return true;
+            }
+            Region region = regions.get(args[1]);
+            if (region != null) {
+                sender.sendMessage("Region " + args[1] + ":");
+                sender.sendMessage("Pos1: " + formatLocation(region.pos1));
+                sender.sendMessage("Pos2: " + formatLocation(region.pos2));
+                int players = countPlayers(region);
+                sender.sendMessage("Players inside: " + players);
+            } else {
+                sender.sendMessage("Region not found");
+            }
+            return true;
+        } else if (sub.equals("list")) {
+            sender.sendMessage("Regions:");
+            for (String key : regions.keySet()) {
+                sender.sendMessage("- " + key);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private Region getSelection(Player player) {
+        WorldEditPlugin we = (WorldEditPlugin) Bukkit.getPluginManager().getPlugin("WorldEdit");
+        if (we == null) {
+            player.sendMessage("WorldEdit not found");
+            return null;
+        }
+        Selection sel = we.getSelection(player);
+        if (sel == null) return null;
+        return new Region(sel.getMinimumPoint(), sel.getMaximumPoint());
+    }
+
+    private String formatLocation(Location loc) {
+        return String.format("%s,%d,%d,%d", loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+    }
+
+    private int countPlayers(Region region) {
+        int count = 0;
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            if (region.contains(p.getLocation())) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static class Region {
+        final Location pos1;
+        final Location pos2;
+
+        Region(Location pos1, Location pos2) {
+            this.pos1 = pos1;
+            this.pos2 = pos2;
+        }
+
+        boolean contains(Location loc) {
+            if (!loc.getWorld().equals(pos1.getWorld())) return false;
+            double x1 = Math.min(pos1.getX(), pos2.getX());
+            double x2 = Math.max(pos1.getX(), pos2.getX());
+            double y1 = Math.min(pos1.getY(), pos2.getY());
+            double y2 = Math.max(pos1.getY(), pos2.getY());
+            double z1 = Math.min(pos1.getZ(), pos2.getZ());
+            double z2 = Math.max(pos1.getZ(), pos2.getZ());
+            return loc.getX() >= x1 && loc.getX() <= x2 &&
+                   loc.getY() >= y1 && loc.getY() <= y2 &&
+                   loc.getZ() >= z1 && loc.getZ() <= z2;
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,9 @@
+name: AreaPlayerControl
+main: com.example.areaplayercontrol.AreaPlayerControl
+version: 1.0
+api-version: '1.21'
+commands:
+  area:
+    description: Manage areas
+    usage: /<command> <save|remove|info|list> [name]
+    aliases: [areaplayercontrol]


### PR DESCRIPTION
## Summary
- setup Gradle build for a new plugin project
- add plugin.yml with `/area` command
- implement `AreaPlayerControl` main class with save, remove, info and list subcommands

## Testing
- `gradle build` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684372787430833082cf003ab32117a1