### PR TITLE
Fix reload and base command registration

### DIFF
--- a/src/main/java/com/example/areaplayercontrol/AreaPlayerControl.java
+++ b/src/main/java/com/example/areaplayercontrol/AreaPlayerControl.java
@@ -232,19 +232,18 @@ public class AreaPlayerControl extends JavaPlugin {
     }
 
     private void registerBaseCommand() {
-        try {
-            Constructor<PluginCommand> cons = PluginCommand.class.getDeclaredConstructor(String.class, JavaPlugin.class);
-            cons.setAccessible(true);
-            PluginCommand alias = cons.newInstance(baseCommand, this);
-            alias.setExecutor(this);
-            alias.setTabCompleter(this);
-            alias.setAliases(Collections.emptyList());
-            alias.setDescription("Manage areas");
-            alias.setUsage("/" + baseCommand + " <" + String.join("|", cmdSave, cmdRemove, cmdInfo, cmdList, cmdMenu, cmdReload) + "> [name]");
-            getCommandMap().register(getDescription().getName(), alias);
-        } catch (Exception e) {
-            getLogger().warning("Failed to register base command alias: " + e.getMessage());
+        PluginCommand cmd = getCommand("areaplayercontrol");
+        if (cmd == null) {
+            getLogger().warning("Base command registration failed");
+            return;
         }
+
+        cmd.setExecutor(this);
+        cmd.setTabCompleter(this);
+        cmd.setAliases(Collections.singletonList(baseCommand));
+        cmd.setDescription("Manage areas");
+        cmd.setUsage("/" + baseCommand + " <" + String.join("|",
+                cmdSave, cmdRemove, cmdInfo, cmdList, cmdMenu, cmdReload) + "> [name]");
     }
 
     private CommandMap getCommandMap() throws Exception {
@@ -268,8 +267,8 @@ public class AreaPlayerControl extends JavaPlugin {
     }
 
     private void reloadPlugin() {
-        saveRegions();
         reloadConfig();
+        saveRegions();
         regions.clear();
         messages.clear();
         descriptions.clear();

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,3 +6,4 @@ commands:
   areaplayercontrol:
     description: Manage areas
     usage: /<command> <save|remove|info|list|menu|reload> [name]
+    aliases: [area]


### PR DESCRIPTION
## Summary
- ensure new config changes aren't overwritten during reload
- register configurable base command using existing command
- provide default `area` alias in `plugin.yml`

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684754376a6c83308a3bae28f09bc209