### PR TITLE
Remove configurable base command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,9 @@ AreaPlayerControl, PaperMC tabanlı Minecraft sunucuları için basit bir alan y
 
 ## Yapılandırma
 
-`config.yml` dosyasıyla ana komut adını ve alt komutları değiştirebilir,
-mesajların Türkçe çevirilerini de özelleştirebilirsiniz. `commands.base`
-anahtarını düzenleyerek eklentinin kullandığı temel komut adını
-belirleyebilirsiniz. Varsayılan değer `area` olup `/area` komutu olarak
-kullanılır.
+`config.yml` dosyasıyla alt komut adlarını değiştirebilir,
+mesajların Türkçe çevirilerini de özelleştirebilirsiniz. Ana komut ismi
+`/area` olarak sabittir ve yapılandırma ile değiştirilemez.
 
 ## Derleme (Jar Oluşturma)
 

--- a/src/main/java/com/example/areaplayercontrol/AreaPlayerControl.java
+++ b/src/main/java/com/example/areaplayercontrol/AreaPlayerControl.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 public class AreaPlayerControl extends JavaPlugin {
     private Map<String, Region> regions = new HashMap<>();
-    private String baseCommand;
+    private final String baseCommand = "area";
     private String cmdSave;
     private String cmdRemove;
     private String cmdInfo;
@@ -41,7 +41,6 @@ public class AreaPlayerControl extends JavaPlugin {
         saveDefaultConfig();
         FileConfiguration config = getConfig();
 
-        baseCommand = config.getString("commands.base", "area").toLowerCase();
         cmdSave = config.getString("commands.save", "save").toLowerCase();
         cmdRemove = config.getString("commands.remove", "remove").toLowerCase();
         cmdInfo = config.getString("commands.info", "info").toLowerCase();
@@ -275,7 +274,6 @@ public class AreaPlayerControl extends JavaPlugin {
 
         FileConfiguration config = getConfig();
 
-        baseCommand = config.getString("commands.base", "area").toLowerCase();
         cmdSave = config.getString("commands.save", "save").toLowerCase();
         cmdRemove = config.getString("commands.remove", "remove").toLowerCase();
         cmdInfo = config.getString("commands.info", "info").toLowerCase();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,4 @@
 commands:
-  base: area
   save: save
   remove: remove
   info: info


### PR DESCRIPTION
## Summary
- remove `commands.base` from the default config
- set base command `/area` as a constant in the plugin
- update README accordingly

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68475707fd7c83308ac8fa69d41412e1