### PR TITLE
Add PlaceholderAPI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ Projenin derlenebilmesi için Java 21 ve Gradle'ın yüklü olması gerekir. Şu
 2. Derleme tamamlandığında `build/libs/AreaPlayerControl-1.0-SNAPSHOT.jar` dosyası oluşur. Bu jar dosyasını PaperMC sunucunuzun `plugins/` klasörüne kopyalayarak eklentiyi kullanmaya başlayabilirsiniz.
 
 WorldEdit eklentisinin sunucuda yüklü olması gerektigini unutmayın.
+
+Eklenti, PlaceholderAPI yüklü ise `areaplayercontrol_regions` adında bir
+placeholder sunar. Bu placeholder kayıtlı bölge sayısını döndürür ve
+TitleManager gibi eklentiler tarafından skorbordda kullanılabilir.

--- a/build.gradle
+++ b/build.gradle
@@ -11,12 +11,15 @@ repositories {
     maven { url 'https://repo.papermc.io/repository/maven-public/' }
     // Repository for WorldEdit
     maven { url 'https://maven.enginehub.org/repo/' }
+    // Repository for PlaceholderAPI
+    maven { url 'https://repo.extendedclip.com/content/repositories/placeholderapi/' }
 }
 
 dependencies {
     compileOnly 'io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT'
     compileOnly 'com.sk89q.worldedit:worldedit-bukkit:7.2.17'
     compileOnly 'com.sk89q.worldedit:worldedit-core:7.2.17'
+    compileOnly 'me.clip:placeholderapi:2.11.5'
 }
 
 java {

--- a/src/main/java/com/example/areaplayercontrol/AreaPlayerControl.java
+++ b/src/main/java/com/example/areaplayercontrol/AreaPlayerControl.java
@@ -23,6 +23,8 @@ import org.bukkit.configuration.file.FileConfiguration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import com.example.areaplayercontrol.RegionPlaceholderExpansion;
 
 public class AreaPlayerControl extends JavaPlugin {
     private Map<String, Region> regions = new HashMap<>();
@@ -35,6 +37,7 @@ public class AreaPlayerControl extends JavaPlugin {
     private String cmdReload;
     private Map<String, String> descriptions = new HashMap<>();
     private Map<String, String> messages = new HashMap<>();
+    private PlaceholderExpansion expansion;
 
     @Override
     public void onEnable() {
@@ -66,11 +69,21 @@ public class AreaPlayerControl extends JavaPlugin {
 
         registerBaseCommand();
         loadRegions();
+
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            expansion = new RegionPlaceholderExpansion(this);
+            expansion.register();
+        } else {
+            getLogger().info("PlaceholderAPI not found, placeholders disabled");
+        }
     }
 
     @Override
     public void onDisable() {
         saveRegions();
+        if (expansion != null) {
+            expansion.unregister();
+        }
     }
 
     private void loadRegions() {
@@ -228,6 +241,10 @@ public class AreaPlayerControl extends JavaPlugin {
             }
         }
         return count;
+    }
+
+    public int getRegionCount() {
+        return regions.size();
     }
 
     private void registerBaseCommand() {

--- a/src/main/java/com/example/areaplayercontrol/RegionPlaceholderExpansion.java
+++ b/src/main/java/com/example/areaplayercontrol/RegionPlaceholderExpansion.java
@@ -1,0 +1,49 @@
+package com.example.areaplayercontrol;
+
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.entity.Player;
+
+/**
+ * PlaceholderAPI expansion providing the number of saved regions.
+ */
+public class RegionPlaceholderExpansion extends PlaceholderExpansion {
+
+    private final AreaPlayerControl plugin;
+
+    public RegionPlaceholderExpansion(AreaPlayerControl plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public boolean canRegister() {
+        return true;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "areaplayercontrol";
+    }
+
+    @Override
+    public String getAuthor() {
+        return String.join(",", plugin.getDescription().getAuthors());
+    }
+
+    @Override
+    public String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public String onPlaceholderRequest(Player player, String identifier) {
+        if (identifier.equalsIgnoreCase("regions") || identifier.equalsIgnoreCase("region_count")) {
+            return String.valueOf(plugin.getRegionCount());
+        }
+        return null;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: AreaPlayerControl
 main: com.example.areaplayercontrol.AreaPlayerControl
 version: 1.0
 api-version: '1.21'
+softdepend: [PlaceholderAPI]
 commands:
   areaplayercontrol:
     description: Manage areas


### PR DESCRIPTION
## Summary
- add PlaceholderAPI as a compileOnly dependency
- register softdepend in plugin.yml
- implement a PlaceholderExpansion that exposes the saved region count
- register/unregister the expansion when the plugin enables/disables
- document placeholder usage in README

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_6847582c6bc08330bd3962013a729b8a