### PR TITLE
Add 1.20 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT'
+    // Compile against the 1.20 API to support 1.20.x servers
+    compileOnly 'io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT'
     compileOnly 'com.sk89q.worldedit:worldedit-bukkit:7.2.17'
     compileOnly 'com.sk89q.worldedit:worldedit-core:7.2.17'
     compileOnly 'me.clip:placeholderapi:2.11.5'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,8 @@
 name: AreaPlayerControl
 main: com.example.areaplayercontrol.AreaPlayerControl
 version: 1.0
-api-version: '1.21'
+# Target API version 1.20 for compatibility with 1.20.x servers
+api-version: '1.20'
 softdepend: [PlaceholderAPI]
 commands:
   areaplayercontrol:


### PR DESCRIPTION
## Summary
- compile against Paper 1.20 API
- set plugin api-version to 1.20

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68476f784f3c8330bd799f5a4a82f924