### PR TITLE
Add Paper 1.20.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 AreaPlayerControl, PaperMC tabanlı Minecraft sunucuları için basit bir alan yönetim eklentisidir. WorldEdit eklentisinden yararlanarak seçtiğiniz bölgeleri kaydetmenizi, silmenizi ve listelemenizi sağlar. Ayrıca kayıtlı bölgeler içindeki oyuncu sayısını görüntülemeye yarayan bir `info` komutuna sahiptir.
 
+Bu sürüm 1.20.x ve 1.21.x PaperMC sunucularıyla uyumludur.
+
 ## Komutlar
 
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT'
+    // Compile against the 1.20.6 API for compatibility with 1.20.x and 1.21.x servers
+    compileOnly 'io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT'
     compileOnly 'com.sk89q.worldedit:worldedit-bukkit:7.2.17'
     compileOnly 'com.sk89q.worldedit:worldedit-core:7.2.17'
     compileOnly 'me.clip:placeholderapi:2.11.5'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: AreaPlayerControl
 main: com.example.areaplayercontrol.AreaPlayerControl
 version: 1.0
-api-version: '1.21'
+api-version: '1.20'
 softdepend: [PlaceholderAPI]
 commands:
   areaplayercontrol:


### PR DESCRIPTION
## Summary
- build against Paper 1.20.6 API for broad compatibility
- mark plugin.yml with `api-version: 1.20`
- document supported versions in README

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6847715e9e8483308059fddc42e997d4