### PR TITLE
Restrict plugin usage to ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ AreaPlayerControl, PaperMC tabanlı Minecraft sunucuları için basit bir alan y
 
 Bu sürüm 1.20.x ve 1.21.x PaperMC sunucularıyla uyumludur.
 
+Komutların çalışabilmesi için oyuncunun OP yetkisine sahip olması gerekir.
+
 ## Komutlar
 
 ```

--- a/src/main/java/com/example/areaplayercontrol/AreaPlayerControl.java
+++ b/src/main/java/com/example/areaplayercontrol/AreaPlayerControl.java
@@ -113,6 +113,14 @@ public class AreaPlayerControl extends JavaPlugin {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(msg("onlyPlayers"));
+            return true;
+        }
+        if (!sender.isOp()) {
+            sender.sendMessage(msg("noPermission"));
+            return true;
+        }
         if (args.length == 0) {
             // Show the command menu when no sub command is provided
             sender.sendMessage(msg("menuHeader"));
@@ -126,10 +134,6 @@ public class AreaPlayerControl extends JavaPlugin {
         }
         String sub = args[0].toLowerCase();
         if (sub.equals(cmdSave)) {
-            if (!(sender instanceof Player)) {
-                sender.sendMessage(msg("onlyPlayers"));
-                return true;
-            }
             if (args.length < 2) {
                 sender.sendMessage(msg("usageSave").replace("%cmd%", baseCommand).replace("%save%", cmdSave));
                 return true;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -16,6 +16,7 @@ descriptions:
 
 messages:
   onlyPlayers: "&cBu komutu sadece oyuncular kullanabilir."
+  noPermission: "&cBu komutu kullanmak için OP olmalısınız."
   needSelection: "&cÖnce bir WorldEdit seçimi yapmalısınız."
   regionSaved: "&aBölge &e%name% &abaşarıyla kaydedildi."
   usageSave: "&eKullanım: /%cmd% %save% <isim>"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,3 +8,10 @@ commands:
     description: Manage areas
     usage: /<command> <save|remove|info|list|menu|reload> [name]
     aliases: [area]
+    permission: areaplayercontrol.admin
+    permission-message: "&cBu komutu kullanmak için yetkiniz yok."
+
+permissions:
+  areaplayercontrol.admin:
+    description: Allows use of AreaPlayerControl commands
+    default: op


### PR DESCRIPTION
## Summary
- mention OP-only requirement in README
- add noPermission message in config
- enforce OP check in command handler
- declare permission in plugin.yml

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68479771d44c83308e44f0961b1ce198